### PR TITLE
puppet-timezone: Added support for CentOS and AWS Linux.

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -1,6 +1,6 @@
 class timezone::params {
   case $::operatingsystem {
-    /(Ubuntu|Debian|Gentoo)/: {
+    /(Ubuntu|Debian|Gentoo|CentOS|Amazon)/: {
       $package = 'tzdata'
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $config_file = '/etc/localtime'


### PR DESCRIPTION
Hi,

I added support for CentOS and AWS Linux. I tested it on both OS as well.

CentOS:
![image](https://f.cloud.github.com/assets/2142512/482194/6378e7b8-b88c-11e2-9f45-5607c2069bef.png)

AWS Linux:
![image](https://f.cloud.github.com/assets/2142512/482202/b9621320-b88c-11e2-91ed-3c00febee130.png)
