### PR TITLE
Add FreeBSD support

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -43,8 +43,8 @@
 #
 # [Remember: No empty lines between comments and class definition]
 class timezone (
-  $ensure = 'present',
-  $timezone = 'UTC',
+  $ensure      = 'present',
+  $timezone    = 'UTC',
   $autoupgrade = false
 ) inherits timezone::params {
 
@@ -71,8 +71,11 @@ class timezone (
     }
   }
 
-  package { $timezone::params::package:
-    ensure => $package_ensure,
+  if $timezone::params::package {
+    package { $timezone::params::package:
+      ensure => $package_ensure,
+      before => File[$timezone::params::localtime_file],
+    }
   }
 
   if $timezone::params::timezone_file != false {
@@ -95,8 +98,7 @@ class timezone (
   }
 
   file { $timezone::params::localtime_file:
-    ensure  => $localtime_ensure,
-    target  => "${timezone::params::zoneinfo_dir}${timezone}",
-    require => Package[$timezone::params::package],
+    ensure => $localtime_ensure,
+    target => "${timezone::params::zoneinfo_dir}${timezone}",
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -42,6 +42,12 @@ class timezone::params {
       $timezone_file = false
       $timezone_update = 'zic -l '
     }
+    'FreeBSD': {
+      $package      = undef
+      $zoneinfo_dir = '/usr/share/zoneinfo/'
+      $localtime_file = '/etc/localtime'
+      $timezone_file = false
+    }
     default: {
       case $::operatingsystem {
         default: {

--- a/spec/classes/timezone_spec.rb
+++ b/spec/classes/timezone_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe 'timezone' do
-  ['Debian','RedHat','Gentoo'].each do |osfamily|
+  ['Debian','RedHat','Gentoo','FreeBSD'].each do |osfamily|
     describe "on supported osfamily: #{osfamily}" do
       include_examples osfamily
     end

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -7,7 +7,12 @@ shared_examples 'Debian' do
     it { should create_class('timezone') }
     it { should contain_class('timezone::params') }
 
-    it { should contain_package('tzdata').with_ensure('present') }
+    it do
+      should contain_package('tzdata').with({
+        :ensure => 'present',
+        :before => "File[/etc/localtime]",
+      })
+    end
 
     it { should contain_file('/etc/timezone').with_ensure('file') }
     it { should contain_file('/etc/timezone').with_content(/^UTC$/) }
@@ -17,7 +22,6 @@ shared_examples 'Debian' do
       should contain_file('/etc/localtime').with({
         :ensure => 'link',
         :target => '/usr/share/zoneinfo/UTC',
-        :require  => "Package[tzdata]",
       })
     end
 

--- a/spec/support/freebsd.rb
+++ b/spec/support/freebsd.rb
@@ -1,23 +1,11 @@
-shared_examples 'RedHat' do
-  let(:facts) {{ :osfamily => "RedHat" }}
+shared_examples 'FreeBSD' do
+  let(:facts) {{ :osfamily => "FreeBSD" }}
 
   describe "when using default class parameters" do
     let(:params) {{ }}
 
     it { should create_class('timezone') }
     it { should contain_class('timezone::params') }
-
-    it do
-      should contain_package('tzdata').with({
-        :ensure => 'present',
-        :before => 'File[/etc/localtime]',
-      })
-    end
-
-
-    it { should contain_file('/etc/sysconfig/clock').with_ensure('file') }
-    it { should contain_file('/etc/sysconfig/clock').with_content(/^ZONE="UTC"$/) }
-    it { should_not contain_exec('update_timezone') }
 
     it do
       should contain_file('/etc/localtime').with({
@@ -29,19 +17,15 @@ shared_examples 'RedHat' do
     context 'when timezone => "Europe/Berlin"' do
       let(:params) {{ :timezone => "Europe/Berlin" }}
 
-      it { should contain_file('/etc/sysconfig/clock').with_content(/^ZONE="Europe\/Berlin"$/) }
       it { should contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do
       let(:params) {{ :autoupgrade => true }}
-      it { should contain_package('tzdata').with_ensure('latest') }
     end
 
     context 'when ensure => absent' do
       let(:params) {{ :ensure => 'absent' }}
-      it { should contain_package('tzdata').with_ensure('present') }
-      it { should contain_file('/etc/sysconfig/clock').with_ensure('absent') }
       it { should contain_file('/etc/localtime').with_ensure('absent') }
     end
 

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -7,7 +7,12 @@ shared_examples 'Gentoo' do
     it { should create_class('timezone') }
     it { should contain_class('timezone::params') }
 
-    it { should contain_package('sys-libs/timezone-data').with_ensure('present') }
+    it do
+      should contain_package('sys-libs/timezone-data').with({
+        :ensure => 'present',
+        :before => 'File[/etc/localtime]',
+      })
+    end
 
     it { should contain_file('/etc/timezone').with_ensure('file') }
     it { should contain_file('/etc/timezone').with_content(/^UTC$/) }
@@ -16,7 +21,6 @@ shared_examples 'Gentoo' do
       should contain_file('/etc/localtime').with({
         :ensure => 'link',
         :target => '/usr/share/zoneinfo/UTC',
-        :require  => "Package[sys-libs/timezone-data]",
       })
     end
 


### PR DESCRIPTION
NTP is installed in FreeBSD's base system thus this commit disables installation of the NTP package while still allowing management of the NTP service.