### PR TITLE
templates/timezone.erb: Remove managed by puppet comment

### DIFF
--- a/templates/timezone.erb
+++ b/templates/timezone.erb
@@ -1,2 +1,1 @@
-# Managed by puppet - do not modify
 <%= @timezone %>


### PR DESCRIPTION
(partial revert of 5aae6a23c2339f1c7a325171f64f4b8efcc4c2a6, pull request #17 from jlambert121/issue_14)

/etc/timezone is rewritten by dpkg-reconfigure tzdata on debian, which is triggered when this file is updated.  This causes an infinite loop of adding and removing the comment on every puppet run.