### PR TITLE
Make comment in timezone file conditional

### DIFF
--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -10,6 +10,7 @@ class timezone::params {
       $localtime_file = '/etc/localtime'
       $timezone_file = '/etc/timezone'
       $timezone_file_template = 'timezone/timezone.erb'
+      $timezone_file_supports_comment = false
       $timezone_update = 'dpkg-reconfigure -f noninteractive tzdata'
     }
     'RedHat', 'Linux': {
@@ -33,6 +34,7 @@ class timezone::params {
       $localtime_file = '/etc/localtime'
       $timezone_file = '/etc/timezone'
       $timezone_file_template = 'timezone/timezone.erb'
+      $timezone_file_supports_comment = true
       $timezone_update = 'emerge --config timezone-data'
     }
     'Archlinux': {

--- a/templates/timezone.erb
+++ b/templates/timezone.erb
@@ -1,2 +1,4 @@
+<%- if @timezone_file_supports_comment -%>
 # Managed by puppet - do not modify
+<%- end -%>
 <%= @timezone %>


### PR DESCRIPTION
Comments in the /etc/timezone file on Debian are removed by
dpkg-reconfigure, resulting in a refresh of the timezone setting
on every manifest run.