### PR TITLE
Resolves issues with timezone links not being honored when copied

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -121,5 +121,7 @@ class timezone (
   file { $timezone::params::localtime_file:
     ensure => $localtime_ensure,
     source => "file://${timezone::params::zoneinfo_dir}${timezone}",
+    links  => follow,
+    mode   => '0644',
   }
 }


### PR DESCRIPTION
If timezones are link files they will be an invalid file copy (a link to the location that the timezone links to instead of an actual file). This fixes that so it follows links properly. This should be merged ASAP as it will completely break servers if they have timezones the users specify that are links.
