### PR TITLE
update timezone command at RedHat family

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -103,18 +103,19 @@ class timezone (
     file { $timezone::params::timezone_file:
       ensure  => $timezone_ensure,
       content => template($timezone::params::timezone_file_template),
+      notify  => Exec['update_timezone'],
     }
-    if $ensure == 'present' and $timezone::params::timezone_update {
-      $e_command = $timezone::params::timezone_update_arg ? {
-        true  => "${timezone::params::timezone_update} ${timezone}",
-        false => $timezone::params::timezone_update
-      }
-      exec { 'update_timezone':
-        command     => $e_command,
-        path        => '/usr/bin:/usr/sbin:/bin:/sbin',
-        subscribe   => File[$timezone::params::timezone_file],
-        refreshonly => true,
-      }
+  }
+
+  if $ensure == 'present' and $timezone::params::timezone_update {
+    $e_command = $timezone::params::timezone_update_arg ? {
+      true  => "${timezone::params::timezone_update} ${timezone}",
+      false => $timezone::params::timezone_update
+    }
+    exec { 'update_timezone':
+      command     => $e_command,
+      path        => '/usr/bin:/usr/sbin:/bin:/sbin',
+      refreshonly => true,
     }
   }
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -119,8 +119,19 @@ class timezone (
     }
   }
 
-  file { $timezone::params::localtime_file:
-    ensure => $localtime_ensure,
-    source => "file://${timezone::params::zoneinfo_dir}${timezone}",
+  if $ensure == 'absent' {
+    file { $timezone::params::localtime_file:
+      ensure => 'absent',
+    }
+  } elsif $timezone::params::localtime_file_type == 'link' {
+    file { $timezone::params::localtime_file:
+      ensure => 'link',
+      target => "file://${timezone::params::zoneinfo_dir}${timezone}",
+    }
+  } elsif $timezone::params::localtime_file_type == 'file' {
+    file { $timezone::params::localtime_file:
+      ensure => 'file',
+      source => "file://${timezone::params::zoneinfo_dir}${timezone}",
+    }
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -105,9 +105,9 @@ class timezone (
       content => template($timezone::params::timezone_file_template),
     }
     if $ensure == 'present' and $timezone::params::timezone_update {
-      $e_command = $::osfamily ? {
-        /(Suse|Archlinux)/ => "${timezone::params::timezone_update} ${timezone}",
-        default            => $timezone::params::timezone_update
+      $e_command = $timezone::params::timezone_update_arg ? {
+        true  => "${timezone::params::timezone_update} ${timezone}",
+        false => $timezone::params::timezone_update
       }
       exec { 'update_timezone':
         command     => $e_command,

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -126,7 +126,7 @@ class timezone (
   } elsif $timezone::params::localtime_file_type == 'link' {
     file { $timezone::params::localtime_file:
       ensure => 'link',
-      target => "file://${timezone::params::zoneinfo_dir}${timezone}",
+      target => "${timezone::params::zoneinfo_dir}${timezone}",
     }
   } elsif $timezone::params::localtime_file_type == 'file' {
     file { $timezone::params::localtime_file:

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -26,7 +26,7 @@ class timezone::params {
         }
       }
       $timezone_file_template = 'timezone/clock.erb'
-      $timezone_update = false
+      $timezone_update = 'tzdata-update'
     }
     'Gentoo': {
       $package = 'sys-libs/timezone-data'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -12,6 +12,7 @@ class timezone::params {
       $timezone_file_template = 'timezone/timezone.erb'
       $timezone_file_supports_comment = false
       $timezone_update = 'dpkg-reconfigure -f noninteractive tzdata'
+      $timezone_update_arg = false
     }
     'RedHat', 'Linux': {
       $package = 'tzdata'
@@ -27,6 +28,7 @@ class timezone::params {
       }
       $timezone_file_template = 'timezone/clock.erb'
       $timezone_update = 'tzdata-update'
+      $timezone_update_arg = false
     }
     'Gentoo': {
       $package = 'sys-libs/timezone-data'
@@ -36,6 +38,7 @@ class timezone::params {
       $timezone_file_template = 'timezone/timezone.erb'
       $timezone_file_supports_comment = true
       $timezone_update = 'emerge --config timezone-data'
+      $timezone_update_arg = false
     }
     'Archlinux': {
       $package = 'tzdata'
@@ -43,6 +46,7 @@ class timezone::params {
       $localtime_file = '/etc/localtime'
       $timezone_file = false
       $timezone_update = 'timedatectl set-timezone '
+      $timezone_update_arg = true
     }
     'Suse': {
       $package = 'timezone'
@@ -50,6 +54,7 @@ class timezone::params {
       $localtime_file = '/etc/localtime'
       $timezone_file = false
       $timezone_update = 'zic -l '
+      $timezone_update_arg = true
     }
     'FreeBSD': {
       $package      = undef

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -18,17 +18,16 @@ class timezone::params {
       $package = 'tzdata'
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
-      case $::operatingsystemmajrelease {
-        '7': {
-          $timezone_file = false
-        }
-        default: {
-          $timezone_file = '/etc/sysconfig/clock'
-        }
+      if $::operatingsystemmajrelease == '7' {
+        $timezone_file = false
+        $timezone_update = 'timedatectl set-timezone '
+        $timezone_update_arg = true
+      } else {
+        $timezone_file_template = 'timezone/clock.erb'
+        $timezone_file = '/etc/sysconfig/clock'
+        $timezone_update = 'tzdata-update'
+        $timezone_update_arg = false
       }
-      $timezone_file_template = 'timezone/clock.erb'
-      $timezone_update = 'tzdata-update'
-      $timezone_update_arg = false
     }
     'Gentoo': {
       $package = 'sys-libs/timezone-data'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -8,6 +8,7 @@ class timezone::params {
       $package = 'tzdata'
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
+      $localtime_file_type = 'file'
       $timezone_file = '/etc/timezone'
       $timezone_file_template = 'timezone/timezone.erb'
       $timezone_file_supports_comment = false
@@ -22,17 +23,20 @@ class timezone::params {
         $timezone_file = false
         $timezone_update = 'timedatectl set-timezone '
         $timezone_update_arg = true
+        $localtime_file_type = 'link'
       } else {
         $timezone_file_template = 'timezone/clock.erb'
         $timezone_file = '/etc/sysconfig/clock'
         $timezone_update = 'tzdata-update'
         $timezone_update_arg = false
+        $localtime_file_type = 'file'
       }
     }
     'Gentoo': {
       $package = 'sys-libs/timezone-data'
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
+      $localtime_file_type = 'file'
       $timezone_file = '/etc/timezone'
       $timezone_file_template = 'timezone/timezone.erb'
       $timezone_file_supports_comment = true
@@ -43,6 +47,7 @@ class timezone::params {
       $package = 'tzdata'
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
+      $localtime_file_type = 'file'
       $timezone_file = false
       $timezone_update = 'timedatectl set-timezone '
       $timezone_update_arg = true
@@ -51,6 +56,7 @@ class timezone::params {
       $package = 'timezone'
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
+      $localtime_file_type = 'file'
       $timezone_file = false
       $timezone_update = 'zic -l '
       $timezone_update_arg = true
@@ -59,6 +65,7 @@ class timezone::params {
       $package      = undef
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
+      $localtime_file_type = 'file'
       $timezone_file = false
     }
     default: {

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -48,6 +48,7 @@ shared_examples 'RedHat' do
     context 'when RHEL 7' do
       let(:facts) {{ :osfamily => "RedHat", :operatingsystemmajrelease => '7' }}
       it { should_not contain_file('/etc/sysconfig/clock').with_ensure('file') }
+      it { should contain_exec('update_timezone').with_command('timedatectl set-timezone  Etc/UTC') }
     end
 
     include_examples 'validate parameters'

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -54,11 +54,13 @@ shared_examples 'RedHat' do
     let(:facts) {{ :osfamily => "RedHat", :operatingsystemmajrelease => '7' }}
     it { should_not contain_file('/etc/sysconfig/clock').with_ensure('file') }
     it { should contain_exec('update_timezone').with_command('timedatectl set-timezone  Etc/UTC') }
+    it { should contain_file('/etc/localtime').with_target('file:///usr/share/zoneinfo/Etc/UTC') }
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) {{ :timezone => "Europe/Berlin" }}
 
       it { should contain_exec('update_timezone').with_command('timedatectl set-timezone  Europe/Berlin') }
+      it { should contain_file('/etc/localtime').with_target('file:///usr/share/zoneinfo/Europe/Berlin') }
     end
   end
 end

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -54,13 +54,13 @@ shared_examples 'RedHat' do
     let(:facts) {{ :osfamily => "RedHat", :operatingsystemmajrelease => '7' }}
     it { should_not contain_file('/etc/sysconfig/clock').with_ensure('file') }
     it { should contain_exec('update_timezone').with_command('timedatectl set-timezone  Etc/UTC') }
-    it { should contain_file('/etc/localtime').with_target('file:///usr/share/zoneinfo/Etc/UTC') }
+    it { should contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Etc/UTC') }
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) {{ :timezone => "Europe/Berlin" }}
 
       it { should contain_exec('update_timezone').with_command('timedatectl set-timezone  Europe/Berlin') }
-      it { should contain_file('/etc/localtime').with_target('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { should contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
   end
 end

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -17,7 +17,7 @@ shared_examples 'RedHat' do
 
     it { should contain_file('/etc/sysconfig/clock').with_ensure('file') }
     it { should contain_file('/etc/sysconfig/clock').with_content(/^ZONE="Etc\/UTC"$/) }
-    it { should_not contain_exec('update_timezone') }
+    it { should contain_exec('update_timezone').with_command('tzdata-update') }
 
     it do
       should contain_file('/etc/localtime').with({


### PR DESCRIPTION
### RHEL/CentOS 6

`tzdata-update` create /etc/localtime as file (not symbolic link) from /etc/sysconfig/clock.

This program is called by some other package's upgrade like glibc-common, so this way is more suitable.
### RHEL/CentOS 7

`timedatectl` create /etc/localtime as symbolic link, like Arch Linux and doesn't need `/etc/sysconfig/clock`
