### PR TITLE
Replace exec with debconf resources for Debian

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -3,5 +3,8 @@ fixtures:
     stdlib:
       repo: https://github.com/puppetlabs/puppetlabs-stdlib.git
       ref: 4.1.0
+    debconf:
+      repo: https://github.com/smoeding/puppet-debconf.git
+      ref: v1.0.0
   symlinks:
     timezone: "#{source_dir}"

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -82,15 +82,15 @@ class timezone (
       $area = $_area[0]
       $_zone = split($timezone, '/')
       $zone = $_zone[1]
-      exec { 'update_debconf area':
-        command => "echo tzdata tzdata/Areas select ${area} | debconf-set-selections",
-        unless  => "debconf-get-selections |grep -q -E \"^tzdata\\s+tzdata/Areas\\s+select\\s+${area}\"",
-        path    => $::path,
+      debconf { 'update_debconf area':
+        item  => 'tzdata/Areas',
+        type  => 'select',
+        value => $area,
       }
-      exec { 'update_debconf zone':
-        command => "echo tzdata tzdata/Zones/${area} select ${timezone} | debconf-set-selections",
-        unless  => "debconf-get-selections |grep -E \"^tzdata\\s+tzdata/Zones/${area}\\s+select\\s+${zone}\"",
-        path    => $::path,
+      debconf { 'update_debconf zone':
+        item  => "tzdata/Zones/${area}",
+        type  => 'select',
+        value => $zone,
       }
     }
     package { $timezone::params::package:

--- a/metadata.json
+++ b/metadata.json
@@ -47,6 +47,10 @@
     {
       "name": "puppetlabs/stdlib",
       "version_requirement": ">= 2.3.0"
+    },
+    {
+      "name": "stm/debconf",
+      "version_requirement": ">= 1.0.0"
     }
   ]
 }


### PR DESCRIPTION
This commit replaces the currently used exec resources on Debian. These exec resource are used to update the debconf database with the selected timezone settings. They use programs provided by the
_debconf-utils_ package, which is only an optional package in Debian. This can cause failures if the package is not installed (mentioned in #28).

The debconf type is a native type (cheeky self promotion - I wrote the module) that only requires the _debconf_ package. This package should already be installed on all Debian based systems since it is a required package.

This commit together with the commit from PR #34 should really fix the Debian convergence problems from issues #27/#28.
