### PR TITLE
Support OpenBSD

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -62,7 +62,11 @@ class timezone (
       } else {
         $package_ensure = 'present'
       }
-      $localtime_ensure = 'file'
+      if $timezone::params::localtime_symlink {
+        $localtime_ensure = 'symlink'
+      } else {
+        $localtime_ensure = 'file'
+      }
       $timezone_ensure = 'file'
     }
     /(absent)/: {
@@ -118,8 +122,15 @@ class timezone (
     }
   }
 
-  file { $timezone::params::localtime_file:
-    ensure => $localtime_ensure,
-    source => "file://${timezone::params::zoneinfo_dir}${timezone}",
+  if $localtime_ensure == 'symlink' {
+    file { $timezone::params::localtime_file:
+      ensure => $localtime_ensure,
+      target => "${timezone::params::zoneinfo_dir}${timezone}",
+    }
+  } else {
+    file { $timezone::params::localtime_file:
+      ensure => $localtime_ensure,
+      source => "file://${timezone::params::zoneinfo_dir}${timezone}",
+    }
   }
 }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,10 +51,17 @@ class timezone::params {
       $timezone_file = false
       $timezone_update = 'zic -l '
     }
-    'FreeBSD', 'OpenBSD': {
+    'FreeBSD': {
       $package      = undef
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
+      $timezone_file = false
+    }
+    'OpenBSD': {
+      $package      = undef
+      $zoneinfo_dir = '/usr/share/zoneinfo/'
+      $localtime_file = '/etc/localtime'
+      $localtime_symlink = true
       $timezone_file = false
     }
     default: {

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,7 +51,7 @@ class timezone::params {
       $timezone_file = false
       $timezone_update = 'zic -l '
     }
-    /(Free|Open)BSD/: {
+    'FreeBSD', 'OpenBSD': {
       $package      = undef
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -51,7 +51,7 @@ class timezone::params {
       $timezone_file = false
       $timezone_update = 'zic -l '
     }
-    'FreeBSD': {
+    /(Free|Open)BSD/: {
       $package      = undef
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'


### PR DESCRIPTION
OpenBSD likes `/etc/localtime` to be a symlink to the appropriate part in `/usr/share/zoneinfo`.

Tested on OpenBSD 6.0 / Puppet 4.7.0.
