### PR TITLE
workaround for deprecated validation function

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,7 +53,7 @@ class timezone (
   $autoupgrade = false
 ) inherits timezone::params {
 
-  if versioncmp($clientversion, '4.4') => 0 {
+  if versioncmp($clientversion, '4.4') >= 0 {
     validate_legacy(Boolean, 'validate_bool', $hwutc)
     validate_legacy(Boolean, 'validate_bool', $autoupgrade)
   } else {

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -53,9 +53,15 @@ class timezone (
   $autoupgrade = false
 ) inherits timezone::params {
 
-  validate_bool($hwutc)
-  validate_bool($autoupgrade)
-
+  if versioncmp($clientversion, '4.4') => 0 {
+    validate_legacy(Boolean, 'validate_bool', $hwutc)
+    validate_legacy(Boolean, 'validate_bool', $autoupgrade)
+  } else {
+    # Legacy function
+    validate_bool($hwutc)
+    validate_bool($autoupgrade)
+  }
+ 
   case $ensure {
     /(present)/: {
       if $autoupgrade == true {


### PR DESCRIPTION
Wanting to avoid warnings when running Puppet but not wanting to work with a local fork I hope to be able to contribute something back. This is my attempt to work around the 'validate_bool' deprecation message. Please engage in a discussion if it is rejected so I can understand what I do wrong (am new to the whole GitHub scene).