### PR TITLE
This commit moves from $::osfamily to $::facts['os']['family']

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ spec/fixtures
 .vagrant
 .bundle/
 vendor/
+log/

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -73,7 +73,7 @@ class timezone (
   }
 
   if $timezone::params::package {
-    if $package_ensure == 'present' and $::osfamily == 'Debian' {
+    if $package_ensure == 'present' and $::facts['os']['family'] == 'Debian' {
       $_area = split($timezone, '/')
       $area = $_area[0]
       $_zone = split($timezone, '/')

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -3,7 +3,7 @@
 # Defines all the variables used in the module.
 #
 class timezone::params {
-  case $::osfamily {
+  case $::facts['os']['family'] {
     'Debian': {
       $package = 'tzdata'
       $zoneinfo_dir = '/usr/share/zoneinfo/'
@@ -19,7 +19,7 @@ class timezone::params {
       $package = 'tzdata'
       $zoneinfo_dir = '/usr/share/zoneinfo/'
       $localtime_file = '/etc/localtime'
-      if $::operatingsystemmajrelease == '7' {
+      if $::facts['os']['release']['major'] == '7' {
         $timezone_file = false
         $timezone_update = 'timedatectl set-timezone '
         $timezone_update_arg = true
@@ -83,11 +83,7 @@ class timezone::params {
       $timezone_file = false
     }
     default: {
-      case $::operatingsystem {
-        default: {
-          fail("Unsupported platform: ${::osfamily}/${::operatingsystem}")
-        }
-      }
+      fail("Unsupported platform: ${::facts['os']['family']}/${::facts['os']['release']['major']}")
     }
   }
 }

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -1,5 +1,5 @@
 shared_examples 'Debian' do
-  let(:facts) { { osfamily: 'Debian' } }
+  let(:facts) { { os: {"name"=>"Debian", "family"=>"Debian", } } }
 
   describe 'when using default class parameters' do
     let(:params) { {} }

--- a/spec/support/freebsd.rb
+++ b/spec/support/freebsd.rb
@@ -1,5 +1,5 @@
 shared_examples 'FreeBSD' do
-  let(:facts) { { osfamily: 'FreeBSD' } }
+  let(:facts) { { os: {"name"=>"FreeBSD", "family"=>"FreeBSD", } } }
 
   describe 'when using default class parameters' do
     let(:params) { {} }

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -1,5 +1,5 @@
 shared_examples 'Gentoo' do
-  let(:facts) { { osfamily: 'Gentoo' } }
+  let(:facts) { { os: {"name"=>"Gentoo", "family"=>"Gentoo", } } }
 
   describe 'when using default class parameters' do
     let(:params) { {} }

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -1,5 +1,5 @@
 shared_examples 'RedHat' do
-  let(:facts) { { osfamily: 'RedHat', operatingsystemmajrelease: '6' } }
+  let(:facts) { { os: {"name"=>"RedHat", "family"=>"RedHat", "release"=>{"major"=>"6", "full"=>"6.7"}, } } }
 
   describe 'when using default class parameters' do
     let(:params) { {} }
@@ -30,7 +30,7 @@ shared_examples 'RedHat' do
   end
 
   context 'when RHEL 6' do
-    let(:facts) { { osfamily: 'RedHat', operatingsystemmajrelease: '6' } }
+    let(:facts) { { os: {"name"=>"RedHat", "family"=>"RedHat", "release"=>{"major"=>"6", "full"=>"6.7"}, } } }
 
     it { is_expected.to contain_file('/etc/sysconfig/clock').with_ensure('file') }
     it { is_expected.to contain_file('/etc/sysconfig/clock').with_content(%r{^ZONE="Etc\/UTC"$}) }
@@ -50,7 +50,7 @@ shared_examples 'RedHat' do
   end
 
   context 'when RHEL 7' do
-    let(:facts) { { osfamily: 'RedHat', operatingsystemmajrelease: '7' } }
+    let(:facts) { { os: {"name"=>"RedHat", "family"=>"RedHat", "release"=>{"major"=>"7", "full"=>"7.3"}, } } }
 
     it { is_expected.not_to contain_file('/etc/sysconfig/clock').with_ensure('file') }
     it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone  Etc/UTC') }


### PR DESCRIPTION
Thus making it clear that facts are used and not variables which
can be set by users.