### PR TITLE
Use debconf instead exec

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -74,17 +74,22 @@ class timezone (
       $_tz = split($timezone, '/')
       $area = $_tz[0]
       $zone = $_tz[1]
-      exec { 'update_debconf area':
-        command => "echo tzdata tzdata/Areas select ${area} | debconf-set-selections",
-        unless  => "debconf-get-selections |grep -q -E \"^tzdata\\s+tzdata/Areas\\s+select\\s+${area}\"",
-        path    => $facts['path'],
+
+      debconf {
+        'tzdata/Areas':
+          package => 'tzdata',
+          item    => 'tzdata/Areas',
+          type    => 'select',
+          value   => $area;
+        "tzdata/Zones/${area}":
+          package => 'tzdata',
+          item    => "tzdata/Zones/${area}",
+          type    => 'select',
+          value   => $zone;
       }
-      exec { 'update_debconf zone':
-        command => "echo tzdata tzdata/Zones/${area} select ${timezone} | debconf-set-selections",
-        unless  => "debconf-get-selections |grep -E \"^tzdata\\s+tzdata/Zones/${area}\\s+select\\s+${zone}\"",
-        path    => $facts['path'],
-      }
+      -> Package[$package]
     }
+
     package { $package:
       ensure => $package_ensure,
       before => File[$localtime_file],

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.7.0 < 6.0.0"
     }
   ],
   "name": "saz-timezone",


### PR DESCRIPTION
Since version v4, the package `debconf-utils` was required.

Using the already required module `stm/debconf` to mange the debconf paramter should be IHMO better instead using hackish exec.

I also bump the max puppet version, because the module runs fine under puppet 5.3.3.