### PR TITLE
Using hiera 5 for data in modules

### DIFF
--- a/hiera.yaml
+++ b/hiera.yaml
@@ -1,14 +1,15 @@
 ---
-version: 4
-datadir: data
+version: 5
+defaults:
+  datadir: 'data'
+  data_hash: 'yaml_data'
+
 hierarchy:
-  - name: "OS major version"
-    backend: yaml
-    path: "os/%{facts.os.family}/%{facts.os.release.major}"
+  - name: 'Operating system major version'
+    path: 'os/%{facts.os.family}/%{facts.os.release.major}.yaml'
 
-  - name: "OS family"
-    backend: yaml
-    path: "os/%{facts.os.family}"
+  - name: 'Operating system family'
+    path: 'os/%{facts.os.family}.yaml'
 
-  - name: "common"
-    backend: yaml
+  - name: 'common'
+    path: 'common.yaml'

--- a/metadata.json
+++ b/metadata.json
@@ -28,7 +28,7 @@
   "requirements": [
     {
       "name": "puppet",
-      "version_requirement": ">= 4.7.0 < 5.0.0"
+      "version_requirement": ">= 4.9.1 < 5.0.0"
     }
   ],
   "name": "saz-timezone",
@@ -42,6 +42,5 @@
   "dependencies": [
     { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 5.0.0" },
     { "name": "stm/debconf", "version_requirement": ">= 2.0.0 < 3.0.0" }
-  ],
-  "data_provider": "hiera"
+  ]
 }


### PR DESCRIPTION
Hiera 4 was only a experimental version and was never released as stable version of hiera. 

Hiera 5 deprecates the data_provider in metadata.json as documentation here: https://puppet.com/docs/puppet/5.3/modules_metadata.html#deprecated-keys

Using 4.9.1 as minimum for data in module like voxpupuli recommendations https://voxpupuli.org/blog/2017/01/11/migrating-to-puppet4/ since the 4.9 had some issue with thie hiera 5