### PR TITLE
Followed links when creating timezone file.

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -114,6 +114,7 @@ class timezone (
   file { $localtime_file:
     ensure => $localtime_ensure,
     source => "file://${zoneinfo_dir}/${timezone}",
+    links  => follow,
     notify => $notify_services,
   }
 


### PR DESCRIPTION
* Resolves issues when selected timezone in /usr/share/zoneinfo is a
  symbolic link.

Fixes #55.