### PR TITLE
links  => follow only works if /etc/localtime is not a symlink already

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class timezone (
       } else {
         $package_ensure = 'present'
       }
-      $localtime_ensure = 'file'
+      $localtime_ensure = 'link'
       $timezone_ensure = 'file'
     }
     /(absent)/: {
@@ -118,8 +118,7 @@ class timezone (
 
   file { $localtime_file:
     ensure => $localtime_ensure,
-    source => "file://${zoneinfo_dir}/${timezone}",
-    links  => follow,
+    target => "${zoneinfo_dir}/${timezone}",
     notify => $notify_services,
   }
 


### PR DESCRIPTION
Hi,

timedatectl creates a relative symlink in place of /etc/localtime and it is not replaced with the file contents when 'links  => follow' is set.

My application requires that the symlink is absolute instead of relative, so create it as an absolute link instead (so that it also complies with 'man 5 localtime').

Otherwise if require => file the result is this:
```
ensure => "file",

Notice: /Stage[main]/Main/File[/etc/localtime]/ensure: ensure changed 'file' to 'link'
```

i.
