### PR TITLE
set timezone correctly on Redhat family version 7 and later

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -115,6 +115,18 @@ class timezone (
       }
     }
   }
+  else {
+    if $facts['os']['family'] == 'RedHat' {
+      $major = $facts['os']['release']['major'] + 0 # adding converts to number
+      if $major >= 7 {
+        exec { 'update_timezone':
+          command => "timedatectl set-timezone ${timezone}",
+          path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+          unless  => "timedatectl status | grep 'Time zone:' | grep -q ${timezone}",
+        }
+      }
+    }
+  }
 
   file { $localtime_file:
     ensure => $localtime_ensure,


### PR DESCRIPTION
As you can see by the attachments, this module failed to correctly set the timezone to US/Eastern on a CentOS (Redhat family) version 7 server. While I will not argue the point that "American/New_York" is equivalent and equal to US/Eastern it is not "US/Eastern" in the strictest sense.

[before-fix-before-after-run.txt](https://github.com/saz/puppet-timezone/files/1756666/before-fix-before-after-run.txt)
[after-fix-before-after-run.txt](https://github.com/saz/puppet-timezone/files/1756667/after-fix-before-after-run.txt)

