### PR TITLE
Adding support for the hwutc parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,12 @@ Manage timezone settings via Puppet
 ## Other class parameters
 * ensure: present or absent, default: present
 * autoupgrade: true or false, default: false. Auto-upgrade package, if there is a newer version
+* hwutc: true or false, default: undef. This parameter will ensure that the real time clock is set to UTC rather than the local timezone. This is not supported on all platforms and will fail if you try and set it on an unsupported platform. A typical error message from the ```timedatectl``` command, if this value is set to false would be:
+```
+Warning: The system is configured to read the RTC time in the local time zone.
+         This mode can not be fully supported. It will create various problems
+         with time zone changes and daylight saving time adjustments. The RTC
+         time is never updated, it relies on external facilities to maintain it.
+         If at all possible, use RTC in UTC by calling
+         'timedatectl set-local-rtc 0'.
+```

--- a/data/os/Debian/16.04.yaml
+++ b/data/os/Debian/16.04.yaml
@@ -1,6 +1,4 @@
 ---
-timezone::timezone_update: 'timedatectl set-timezone %s'
-timezone::timezone_update_check_cmd: "timedatectl status | grep 'Timezone:' | grep -q %s"
 timezone::check_hwclock_enabled_cmd: 'grep LOCAL /etc/adjtime'
 timezone::check_hwclock_disabled_cmd: 'grep UTC /etc/adjtime'
 timezone::hwclock_cmd: 'timedatectl set-local-rtc %s'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -106,8 +106,7 @@ class timezone (
     $exec_subscribe = File[$timezone_file]
     $exec_unless = undef
     $exec_refreshonly = true
-  }
-  else {
+  } else {
     $exec_subscribe = undef
     $exec_unless = lookup('timezone::timezone_update_check_cmd', Optional[String], 'first', undef)
     $exec_refreshonly = false
@@ -116,8 +115,7 @@ class timezone (
   if $ensure == 'present' and $timezone_update {
     if $exec_unless {
       $unless_cmd = sprintf($exec_unless, $timezone)
-    }
-    else {
+    } else {
       $unless_cmd = undef
     }
     exec { 'update_timezone':


### PR DESCRIPTION
This change adds support for the hwutc class parameter. It has been tested on CentOS Linux release 7.0.1406 (Core) and Ubuntu 16.04. 

It also fixes a data error for Red Hat which caused the exec to always run because the check failed.