### PR TITLE
Aligning variable names

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -123,7 +123,7 @@ class timezone (
   }
 
   if $ensure == 'present' and $hwutc != undef {
-    $hwclock_cmd = lookup('timezone::set_hwclock_cmd', Optional[String], 'first', undef)
+    $hwclock_cmd = lookup('timezone::hwclock_cmd', Optional[String], 'first', undef)
     $hwclock_check_enabled_cmd = lookup('timezone::check_hwclock_enabled_cmd', Optional[String], 'first', undef)
     $hwclock_check_disabled_cmd = lookup('timezone::check_hwclock_disabled_cmd', Optional[String], 'first', undef)
 


### PR DESCRIPTION
The hiera data did not match the value lookup was looking for. I changed the lookup key as that ensures overall consistency for the variable name.