### PR TITLE
Fix /etc/localtime to be an actual symlink

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -55,7 +55,7 @@ class timezone (
       } else {
         $package_ensure = 'present'
       }
-      $localtime_ensure = 'file'
+      $localtime_ensure = 'link'
       $timezone_ensure = 'file'
     }
     /(absent)/: {
@@ -144,8 +144,7 @@ class timezone (
 
   file { $localtime_file:
     ensure => $localtime_ensure,
-    source => "file://${zoneinfo_dir}/${timezone}",
-    links  => follow,
+    source => "${zoneinfo_dir}/${timezone}",
     notify => $notify_services,
   }
 }

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -23,15 +23,15 @@ shared_examples 'Debian' do
                                                     :before => 'File[/etc/localtime]')
     end
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/freebsd.rb
+++ b/spec/support/freebsd.rb
@@ -14,14 +14,14 @@ shared_examples 'FreeBSD' do
     it { is_expected.to create_class('timezone') }
 
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -25,15 +25,15 @@ shared_examples 'Gentoo' do
     it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Etc/UTC$}) }
     it { is_expected.to contain_exec('update_timezone').with_command(%r{^emerge --config timezone-data$}) }
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -24,15 +24,15 @@ shared_examples 'RedHat' do
     it { is_expected.not_to contain_exec('update_timezone') }
 
     it do
-      is_expected.to contain_file('/etc/localtime').with(:ensure => 'file',
-                                                         :source => 'file:///usr/share/zoneinfo/Etc/UTC')
+      is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
+                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/sysconfig/clock').with_content(%r{^ZONE="Europe/Berlin"$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('file:///usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do
@@ -66,7 +66,7 @@ shared_examples 'RedHat' do
 
     it { is_expected.to create_class('timezone') }
     it { is_expected.not_to contain_file('/etc/sysconfig/clock') }
-    it { is_expected.to contain_file('/etc/localtime').with_ensure('file') }
+    it { is_expected.to contain_file('/etc/localtime').with_ensure('link') }
     it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC').with_unless('timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC') }
 
     include_examples 'validate parameters'


### PR DESCRIPTION
With the existing code, the /etc/localtime file was created as a hard
link but what is needed by timedatectl is a symlink.

With this patch, /etc/localtime will be created as a symbolic link to
point to /usr/share/zoneinfo/$timezone.
It was tested in a real environment and I was able to configure the
timezone to Japan area, it worked well.