### PR TITLE
Fix Link

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,7 +144,7 @@ class timezone (
 
   file { $localtime_file:
     ensure => $localtime_ensure,
-    source => "${zoneinfo_dir}/${timezone}",
+    target => "${zoneinfo_dir}/${timezone}",
     notify => $notify_services,
   }
 }


### PR DESCRIPTION
Puppet resource 'File' needs attribute `target` set for symbolic links.

