### PR TITLE
Fix link management for localtime

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -97,6 +97,13 @@ class timezone (
     }
   }
 
+  file { $localtime_file:
+    ensure => $localtime_ensure,
+    target => "${zoneinfo_dir}/${timezone}",
+    force  => true,
+    notify => $notify_services,
+  }
+
   if $timezone_file {
     file { $timezone_file:
       ensure  => $timezone_ensure,
@@ -110,6 +117,7 @@ class timezone (
         subscribe   => File[$timezone_file],
         refreshonly => true,
         path        => '/usr/bin:/usr/sbin:/bin:/sbin',
+        require     => File[$localtime_file],
       }
     }
   } else {
@@ -119,6 +127,7 @@ class timezone (
         command => sprintf($timezone_update, $timezone),
         unless  => sprintf($unless_cmd, $timezone),
         path    => '/usr/bin:/usr/sbin:/bin:/sbin',
+        require => File[$localtime_file],
       }
     }
   }
@@ -142,9 +151,4 @@ class timezone (
     }
   }
 
-  file { $localtime_file:
-    ensure => $localtime_ensure,
-    source => "${zoneinfo_dir}/${timezone}",
-    notify => $notify_services,
-  }
 }

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -24,14 +24,14 @@ shared_examples 'Debian' do
     end
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/freebsd.rb
+++ b/spec/support/freebsd.rb
@@ -15,13 +15,13 @@ shared_examples 'FreeBSD' do
 
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -26,14 +26,14 @@ shared_examples 'Gentoo' do
     it { is_expected.to contain_exec('update_timezone').with_command(%r{^emerge --config timezone-data$}) }
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -25,14 +25,14 @@ shared_examples 'RedHat' do
 
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/sysconfig/clock').with_content(%r{^ZONE="Europe/Berlin"$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do


### PR DESCRIPTION
In puppet in order to manage a link, it should use target and not
source. Additionally if the previous instance of the file is not a link
we need force set to true to replace it.  This change should ensure that
on the next run, the /etc/localtime is correctly configured as link to
the appropriate timezone file.