### PR TITLE
Update puppetlabs/stdilb

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -40,7 +40,7 @@
   "description": "Manage timezone settings via Puppet",
   "project_page": "https://github.com/saz/puppet-timezone",
   "dependencies": [
-    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 5.0.0" },
+    { "name": "puppetlabs/stdlib", "version_requirement": ">=2.6.0 < 6.0.0" },
     { "name": "stm/debconf", "version_requirement": ">= 2.0.0 < 3.0.0" }
   ]
 }


### PR DESCRIPTION
This updates the puppetlabs-stdilb dependency from < 5.0.0 to < 6.0.0 and fixes #81 