### PR TITLE
(SIMP-5849) Timezone Update

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -38,8 +38,11 @@ end
 
 group :system_tests do
   if (beaker_version = ENV['BEAKER_VERSION'])
-    gem 'beaker', *location_for(beaker_version)
+    gem 'beaker', *location_for(ENV['BEAKER_VERSION'])
+  else
+    gem 'beaker'
   end
+  gem 'beaker-docker'
   if (beaker_rspec_version = ENV['BEAKER_RSPEC_VERSION'])
     gem 'beaker-rspec', *location_for(beaker_rspec_version)
   else
@@ -54,7 +57,18 @@ else
   gem 'facter', require: false, groups: [:test]
 end
 
-ENV['PUPPET_VERSION'].nil? ? puppetversion = '~> 4.0' : puppetversion = ENV['PUPPET_VERSION'].to_s
+if ENV['PUPPET_VERSION'].nil?
+  case ENV['BEAKER_PUPPET_COLLECTION']
+  when 'puppet5'
+    puppetversion = '~> 5.0'
+  when 'puppet6'
+    puppetversion = '~> 6.0'
+  else
+    puppetversion = '~> 4.0'
+  end
+else
+  puppetversion = ENV['PUPPET_VERSION'].to_s
+end
 gem 'puppet', puppetversion, require: false, groups: [:test]
 
 # vim: syntax=ruby

--- a/data/os/RedHat/7.yaml
+++ b/data/os/RedHat/7.yaml
@@ -4,3 +4,4 @@ timezone::timezone_update_check_cmd: 'timedatectl status | grep "Timezone:\|Time
 timezone::check_hwclock_enabled_cmd: 'grep LOCAL /etc/adjtime'
 timezone::check_hwclock_disabled_cmd: 'grep UTC /etc/adjtime'
 timezone::hwclock_cmd: 'timedatectl set-local-rtc %s'
+3timezone::zoneinfo_dir: '../usr/share/zoneinfo'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -144,7 +144,8 @@ class timezone (
 
   file { $localtime_file:
     ensure => $localtime_ensure,
-    source => "${zoneinfo_dir}/${timezone}",
+    target => "${zoneinfo_dir}/${timezone}",
+    force  => true,
     notify => $notify_services,
   }
 }

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -109,6 +109,7 @@ class timezone (
         command     => sprintf($timezone_update, $timezone),
         subscribe   => File[$timezone_file],
         refreshonly => true,
+        require     => File[$localtime_file],
         path        => '/usr/bin:/usr/sbin:/bin:/sbin',
       }
     }
@@ -118,6 +119,7 @@ class timezone (
       exec { 'update_timezone':
         command => sprintf($timezone_update, $timezone),
         unless  => sprintf($unless_cmd, $timezone),
+        require => File[$localtime_file],
         path    => '/usr/bin:/usr/sbin:/bin:/sbin',
       }
     }

--- a/metadata.json
+++ b/metadata.json
@@ -32,7 +32,7 @@
     }
   ],
   "name": "saz-timezone",
-  "version": "5.0.2",
+  "version": "5.0.3",
   "source": "git://github.com/saz/puppet-timezone",
   "author": "saz",
   "license": "Apache-2.0",

--- a/spec/acceptance/nodesets/centos-6.yml
+++ b/spec/acceptance/nodesets/centos-6.yml
@@ -1,8 +1,8 @@
 HOSTS:
-  centos-7:
-    platform: el-7-x86_64
+  centos-6:
+    platform: el-6-amd64
     hypervisor : docker
-    image: centos:7
+    image: centos:6
     docker_preserve_image: true
     docker_cmd: '["/sbin/init"]'
     docker_image_commands:
@@ -12,3 +12,4 @@ CONFIG:
 <% if ENV['BEAKER_PUPPET_COLLECTION'] -%>
   puppet_collection: <%= ENV['BEAKER_PUPPET_COLLECTION'] %>
 <% end -%>
+

--- a/spec/acceptance/timezone_spec.rb
+++ b/spec/acceptance/timezone_spec.rb
@@ -1,15 +1,30 @@
 require 'spec_helper_acceptance'
 
 describe 'timezone class' do
+
   describe 'running puppet code' do
     it 'works with no errors' do
       pp = <<-PUPPET
-        class { '::timezone': }
+        class { '::timezone': timezone => 'Europe/Rome'}
       PUPPET
-
       # Run it twice and test for idempotency
-      apply_manifest(pp, :catch_failures => true)
-      apply_manifest(pp, :catch_changes => true)
+      apply_manifest( pp, :catch_failures => true)
+      apply_manifest( pp, :catch_changes => true)
+#          result=on(host,%(ls -la /etc/localtime))
+#          expect(result.output).to match(%r(/usr/share))
+    end
+  end
+  describe 'with /etc/localtime an existing file' do
+    it 'can update timezone if localtime is not a link' do
+      result =  %(unlink /etc/localtime ; touch /etc/localtime)
+      check_file = %(ls -la /etc/localtime)
+      expect(check_file).to_not match(%r(->))
+      px = <<-PUPPET
+      class { '::timezone': timezone => 'Europe/Berlin'}
+      PUPPET
+      # Run it twice and test for idempotency
+      apply_manifest( px, :catch_failures => true)
+      apply_manifest( px, :catch_changes => true)
     end
   end
 end

--- a/spec/spec_helper_acceptance.rb
+++ b/spec/spec_helper_acceptance.rb
@@ -1,6 +1,9 @@
 require 'beaker-rspec'
+require 'beaker/puppet_install_helper'
 
-install_puppet_on hosts
+
+run_puppet_install_helper
+#install_puppet_on hosts
 
 RSpec.configure do |c|
   module_root = File.expand_path(File.join(File.dirname(__FILE__), '..'))
@@ -15,6 +18,7 @@ RSpec.configure do |c|
     puppet_module_install(:source => module_root, :module_name => module_name)
     hosts.each do |host|
       on host, puppet('module', 'install', 'puppetlabs-stdlib'), :acceptable_exit_codes => [0, 1]
+      on host, puppet('module', 'install', 'stm/debconf'), :acceptable_exit_codes => [0, 1]
     end
   end
 end

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -16,7 +16,10 @@ shared_examples 'Debian' do
     it { is_expected.to contain_file('/etc/timezone') }
     it { is_expected.to contain_file('/etc/timezone').with_ensure('file') }
     it { is_expected.to contain_file('/etc/timezone').with_content(%r{Etc/UTC}) }
-    it { is_expected.to contain_exec('update_timezone').with_command(%r{^dpkg-reconfigure -f noninteractive tzdata$}) }
+    it { is_expected.to contain_exec('update_timezone').with({
+      'command' => %r{^dpkg-reconfigure -f noninteractive tzdata$},
+      'require' => 'File[/etc/localtime]'
+    })}
 
     it do
       is_expected.to contain_package('tzdata').with(:ensure => 'present',

--- a/spec/support/debian.rb
+++ b/spec/support/debian.rb
@@ -24,14 +24,14 @@ shared_examples 'Debian' do
     end
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/freebsd.rb
+++ b/spec/support/freebsd.rb
@@ -15,13 +15,13 @@ shared_examples 'FreeBSD' do
 
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -26,14 +26,14 @@ shared_examples 'Gentoo' do
     it { is_expected.to contain_exec('update_timezone').with_command(%r{^emerge --config timezone-data$}) }
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Europe/Berlin$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/gentoo.rb
+++ b/spec/support/gentoo.rb
@@ -23,7 +23,10 @@ shared_examples 'Gentoo' do
 
     it { is_expected.to contain_file('/etc/timezone').with_ensure('file') }
     it { is_expected.to contain_file('/etc/timezone').with_content(%r{^Etc/UTC$}) }
-    it { is_expected.to contain_exec('update_timezone').with_command(%r{^emerge --config timezone-data$}) }
+    it { is_expected.to contain_exec('update_timezone').with({
+      :command => %r{^emerge --config timezone-data$},
+      :require => 'File[/etc/localtime]'
+     })}
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
                                                          :target => '/usr/share/zoneinfo/Etc/UTC')

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -25,14 +25,14 @@ shared_examples 'RedHat' do
 
     it do
       is_expected.to contain_file('/etc/localtime').with(:ensure => 'link',
-                                                         :source => '/usr/share/zoneinfo/Etc/UTC')
+                                                         :target => '/usr/share/zoneinfo/Etc/UTC')
     end
 
     context 'when timezone => "Europe/Berlin"' do
       let(:params) { { :timezone => 'Europe/Berlin' } }
 
       it { is_expected.to contain_file('/etc/sysconfig/clock').with_content(%r{^ZONE="Europe/Berlin"$}) }
-      it { is_expected.to contain_file('/etc/localtime').with_source('/usr/share/zoneinfo/Europe/Berlin') }
+      it { is_expected.to contain_file('/etc/localtime').with_target('/usr/share/zoneinfo/Europe/Berlin') }
     end
 
     context 'when autoupgrade => true' do

--- a/spec/support/redhat.rb
+++ b/spec/support/redhat.rb
@@ -67,7 +67,11 @@ shared_examples 'RedHat' do
     it { is_expected.to create_class('timezone') }
     it { is_expected.not_to contain_file('/etc/sysconfig/clock') }
     it { is_expected.to contain_file('/etc/localtime').with_ensure('link') }
-    it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC').with_unless('timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC') }
+    it { is_expected.to contain_exec('update_timezone').with({
+      :command => 'timedatectl set-timezone Etc/UTC',
+      :unless  => 'timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC',
+      :require => 'File[/etc/localtime]'
+    })}
 
     include_examples 'validate parameters'
   end


### PR DESCRIPTION
      - Updated timezone to latest unreleased version.
      - Added `require` for exec to make sure localtime file
        was updated and a link, file was a link first.
        (timedatectl fails if it is not)
      - Added nodeset for centos6.
      - Update Gemfile so tests would work with beaker 3 or 4.
 SIMP-5849 #close
