### PR TITLE
Fix timezone management for SLES 11 and 12

### DIFF
--- a/data/os/Suse/11.yaml
+++ b/data/os/Suse/11.yaml
@@ -1,0 +1,2 @@
+---
+timezone::timezone_file: /etc/sysconfig/clock

--- a/data/os/Suse/11.yaml
+++ b/data/os/Suse/11.yaml
@@ -1,3 +1,3 @@
 ---
 timezone::timezone_file: /etc/sysconfig/clock
-timezone::timezone_file_template: timezone/clock.erb
+timezone::timezone_file_template: timezone/clock_sles11.erb

--- a/data/os/Suse/11.yaml
+++ b/data/os/Suse/11.yaml
@@ -1,2 +1,3 @@
 ---
 timezone::timezone_file: /etc/sysconfig/clock
+timezone::timezone_file_template: timezone/clock.erb

--- a/data/os/Suse/12.yaml
+++ b/data/os/Suse/12.yaml
@@ -1,0 +1,3 @@
+---
+timezone::timezone_update: 'timedatectl set-timezone %s'
+timezone::timezone_update_check_cmd: 'timedatectl status | grep "Timezone:\|Time zone:" | grep -q %s'

--- a/templates/clock_sles11.erb
+++ b/templates/clock_sles11.erb
@@ -1,0 +1,5 @@
+# Managed by puppet - do not modify
+ZONE="<%= @timezone %>"
+<% if !@hwutc.nil? -%>
+UTC=<%= @hwutc %>
+<% end -%>

--- a/templates/clock_sles11.erb
+++ b/templates/clock_sles11.erb
@@ -1,5 +1,34 @@
 # Managed by puppet - do not modify
-ZONE="<%= @timezone %>"
-<% if !@hwutc.nil? -%>
-UTC=<%= @hwutc %>
-<% end -%>
+
+## Path:		System/Environment/Clock
+## Description:		Information about your timezone and time
+## Type:		string(-u,--utc,--localtime)
+## ServiceRestart:	boot.clock
+## Command:		/sbin/refresh_initrd
+#
+# Set to "-u" if your system clock is set to UTC, and to "--localtime"
+# if your clock runs that way.
+#
+HWCLOCK="-u"
+## Description: Write back system time to the hardware clock
+## Type:		yesno
+## Default:		yes
+#
+# Is set to "yes" write back the system time to the hardware
+# clock at reboot or shutdown. Usefull if hardware clock is
+# much more inaccurate than system clock.  Set to "no" if
+# system time does it wrong due e.g. missed timer interrupts.
+# If set to "no" the hardware clock adjust feature is also
+# skipped because it is rather useless without writing back
+# the system time to the hardware clock.
+#
+SYSTOHC="yes"
+
+## Type:		string(Europe/Berlin,Europe/London,Europe/Paris)
+## ServiceRestart:	boot.clock
+#
+# Timezone (e.g. CET)
+# (this will set /usr/lib/zoneinfo/localtime)
+#
+TIMEZONE="<%= @timezone %>"
+DEFAULT_TIMEZONE="<%= @timezone %>"


### PR DESCRIPTION
Fixes #74 

I avoided the option to toggle hardware clock between UTC and the selected timezone. If you switch it (on SLES 12) with "timedatectl set-local-rtc yes" the output of "timedatectl status" does strongly recommend to not do so.
SLES 11 does it with "-u" or "--localtime" in /etc/sysconfig/clock, for which i would have had to handle with the boolean value first.
So the SLES support is depending on the view one has not complete, that is why i also did not extend the metadata.json with that OS.
However it may help the ones, who are brave enough to use the module for SLES nevertheless (like us), so i would be happy if it gets merged. :)
Thanks!