### PR TITLE
Disable comments in timezone file for Gentoo

### DIFF
--- a/data/os/Gentoo.yaml
+++ b/data/os/Gentoo.yaml
@@ -4,5 +4,5 @@ timezone::zoneinfo_dir: /usr/share/zoneinfo
 timezone::localtime_file: /etc/localtime
 timezone::timezone_file: /etc/timezone
 timezone::timezone_file_template: timezone/timezone.erb
-timezone::timezone_file_supports_comment: true
+timezone::timezone_file_supports_comment: false
 timezone::timezone_update: emerge --config timezone-data


### PR DESCRIPTION
We ran into problems with Java on Gentoo which couldn't detect the
correct timezone while having comments in the timezone file. Removing
the comment line fixed the problem.

Not sure if it's the same for other distributions.