### PR TITLE
WIP: Use facts instead of exec to chack current timezone

### DIFF
--- a/data/family/Archlinux.yaml
+++ b/data/family/Archlinux.yaml
@@ -2,4 +2,3 @@ timezone::package: tzdata
 timezone::zoneinfo_dir: /usr/share/zoneinfo
 timezone::localtime_file: /etc/localtime
 timezone::timezone_update: 'timedatectl set-timezone %s'
-timezone::timezone_update_check_cmd: 'timedatectl status | grep "Timezone:\|Time zone:" | grep -q %s'

--- a/data/family/RedHat/7.yaml
+++ b/data/family/RedHat/7.yaml
@@ -1,5 +1,4 @@
 timezone::timezone_update: 'timedatectl set-timezone %s'
-timezone::timezone_update_check_cmd: 'timedatectl status | grep "Timezone:\|Time zone:" | grep -q %s'
 timezone::check_hwclock_enabled_cmd: 'grep LOCAL /etc/adjtime'
 timezone::check_hwclock_disabled_cmd: 'grep UTC /etc/adjtime'
 timezone::hwclock_cmd: 'timedatectl set-local-rtc %s'

--- a/data/family/Suse/12.yaml
+++ b/data/family/Suse/12.yaml
@@ -1,2 +1,1 @@
 timezone::timezone_update: 'timedatectl set-timezone %s'
-timezone::timezone_update_check_cmd: 'timedatectl status | grep "Timezone:\|Time zone:" | grep -q %s'

--- a/data/family/Suse/15.yaml
+++ b/data/family/Suse/15.yaml
@@ -1,2 +1,1 @@
 timezone::timezone_update: 'timedatectl set-timezone %s'
-timezone::timezone_update_check_cmd: 'timedatectl status | grep "Timezone:\|Time zone:" | grep -q %s'

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -122,11 +122,9 @@ class timezone (
       }
     }
   } else {
-    if $ensure == 'present' and $timezone_update {
-      $unless_cmd = lookup('timezone::timezone_update_check_cmd', String, 'first')
+    if $ensure == 'present' and $timezone_update and $facts['timezone'] != $timezone {
       exec { 'update_timezone':
         command => sprintf($timezone_update, $timezone),
-        unless  => sprintf($unless_cmd, $timezone),
         path    => '/usr/bin:/usr/sbin:/bin:/sbin',
         require => File[$localtime_file],
       }

--- a/spec/classes/timezone_spec.rb
+++ b/spec/classes/timezone_spec.rb
@@ -86,7 +86,7 @@ describe 'timezone', type: :class do
           context 'redhat/centos 7, 8' do
             it { is_expected.not_to contain_file('/etc/sysconfig/clock') }
             it { is_expected.to contain_file('/etc/localtime').with_ensure('link') }
-            it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC').with_unless('timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC') }
+            it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC') }
           end
         end # end RedHat version
 
@@ -97,7 +97,7 @@ describe 'timezone', type: :class do
 
             it { is_expected.not_to contain_file('/etc/sysconfig/clock') }
             it { is_expected.to contain_file('/etc/localtime').with_ensure('link') }
-            it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC').with_unless('timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC') }
+            it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC') }
           end
 
           context 'when timezone => "Europe/Berlin"' do
@@ -188,7 +188,7 @@ describe 'timezone', type: :class do
               it { is_expected.to contain_exec('update_timezone').with_command('zic -l Etc/UTC').with(subscribe: 'File[/etc/sysconfig/clock]') }
             else
               it { is_expected.not_to contain_file('/etc/sysconfig/clock') }
-              it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC').with_unless('timedatectl status | grep "Timezone:\|Time zone:" | grep -q Etc/UTC') }
+              it { is_expected.to contain_exec('update_timezone').with_command('timedatectl set-timezone Etc/UTC') }
             end
           end
 


### PR DESCRIPTION
Puppet's built-in facts list includes a `timezone` fact, so it isn't necessary to run extra shell commands to check if the timezone should be changed.

I would prefer if PR #93 were merged before this so the expanded test suite can make sure this doesn't break anything.