### PR TITLE
Allow newer puppetlabs-stdlib versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -58,7 +58,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.6.0 < 7.0.0"
+      "version_requirement": ">= 2.6.0 < 9.0.0"
     },
     {
       "name": "stm/debconf",


### PR DESCRIPTION
7.x and 8.x version should be compatible

https://github.com/puppetlabs/puppetlabs-stdlib/blob/main/CHANGELOG.md