### PR TITLE
Drop puppetlabs/stdlib dependency

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -57,10 +57,6 @@
   ],
   "dependencies": [
     {
-      "name": "puppetlabs/stdlib",
-      "version_requirement": ">= 2.6.0 < 7.0.0"
-    },
-    {
       "name": "stm/debconf",
       "version_requirement": ">= 2.0.0 < 4.0.0"
     }


### PR DESCRIPTION
From looking at the `init.pp` file, I don't see why `puppetlabs/stdlib` needs to be declared as a dependency at all.

So, let's drop it – it was the major reason for changes in the last years, keeping people stuck ;-).

Closes #102.